### PR TITLE
Add nano-CellFM as a community reference implementation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -3,6 +3,9 @@ We have released a **PyTorch version** of [CellFM-torch](https://github.com/biom
 
 In the future, we also plan to **retrain CellFM directly in PyTorch** on the original datasets — stay tuned for exciting updates!
 
+### Community Projects
+**[nano-CellFM](https://github.com/huynguyen250896/nano-CellFM)** — A lightweight, faithful, and easy-to-read reimplementation of CellFM for rapid inference, benchmarking, and research prototyping.
+
 ![](figures/model.png)
 
 <font size=4> We propose a single-cell foundation model, CellFM.  </font> <br><br>


### PR DESCRIPTION
## What is nano-CellFM?

I recently built **nano-CellFM**, a lightweight and faithful PyTorch reimplementation of CellFM designed to make the core implementation easier to read, reproduce, benchmark, and extend while preserving the original architecture and inference behavior.

Repository:
https://github.com/huynguyen250896/nano-CellFM

### Highlights

* **Pure PyTorch implementation** with minimal dependencies
* Reproduces the official CellFM **cell- and gene-level embeddings** from the released CellFM-80M checkpoint
* Cleaner, easy-to-read implementation suitable for learning, benchmarking, experimentation, and future development

### Validation

I carefully validated nano-CellFM against the official implementation to ensure numerical consistency.

Specifically, nano-CellFM:

* reproduces the official cell embeddings with mean cosine similarity ≈ 1.000000
* reproduces the official gene embeddings with mean cosine similarity ≈ 1.000000
* preserves the representation geometry of the official embeddings
* includes reproducibility and inference benchmark notebooks in the repository

Since the official CellFM implementation currently depends on MindSpore and Ascend-oriented tooling, I did not benchmark inference runtime directly against the official implementation. Instead, the repository focuses on providing a fully reproducible PyTorch implementation while reporting inference performance within nano-CellFM itself.

### Why this PR?

The goal of nano-CellFM is not to replace the official implementation, but to provide a lightweight community resource for users who prefer a pure PyTorch implementation for reproducibility, benchmarking, learning, and research. All credit belongs to the official CellFM authors for the original model and its development.

This PR only adds a link under Community Projects. It does not modify any code, pretrained models, datasets, checkpoints, or model behavior.

Thank you for your consideration.